### PR TITLE
Move emails into a separate collection

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import { Admin, Resource } from 'react-admin';
 import { Dashboard } from './components/dashboard';
 import { UserList, UserEdit } from './components/users';
 import { RoomList, RoomEdit } from './components/rooms';
+import { EmailList } from './components/emails';
 import { ReflectionList, ReflectionEdit } from './components/reflections';
 import dataProvider from './providers/dataProvider';
 import authProvider from './providers/authProvider';
@@ -16,6 +17,7 @@ export default function App() {
       authProvider={authProvider}>
       <Resource name="users" list={UserList} edit={UserEdit} />
       <Resource name="rooms" list={RoomList} edit={RoomEdit} />
+      <Resource name="emails" list={EmailList} />
       <Resource name="reflectionResponses" options={{ label: 'Reflections' }} list={ReflectionList} edit={ReflectionEdit}/>
     </Admin>
   );

--- a/src/components/emails.js
+++ b/src/components/emails.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import {
+  List,
+  Datagrid,
+  EmailField,
+  TextField,
+} from 'react-admin';
+
+export function EmailList({permissions, ...props}) {
+  return (
+    <List {...props}
+      bulkActionButtons={false}>
+      <Datagrid rowClick="edit">
+        <TextField source="id" />
+        <EmailField source="email" />
+      </Datagrid>
+    </List>
+  );
+};

--- a/src/components/rooms.js
+++ b/src/components/rooms.js
@@ -32,12 +32,12 @@ export function RoomList({permissions, ...props}) {
         <TextField source="name" />
         <TextField source="code" />
         <TextField source="organisation" />
-        <ReferenceArrayField reference="users" source="facilitatorIds">
+        <ReferenceArrayField reference="emails" source="facilitatorIds">
           <Datagrid>
             <TextField source="email" />
           </Datagrid>
         </ReferenceArrayField>
-        <ReferenceArrayField reference="users" source="participantIds">
+        <ReferenceArrayField reference="emails" source="participantIds">
           <Datagrid>
             <TextField source="email" />
           </Datagrid>
@@ -58,7 +58,7 @@ export function RoomEdit(props) {
         <TextInput source="name" />
         <TextInput source="code" />
         <TextInput source="organisation" />
-        <ReferenceArrayInput reference="users" source="facilitatorIds">
+        <ReferenceArrayInput reference="emails" source="facilitatorIds">
           <SelectArrayInput optionText="email" />
         </ReferenceArrayInput>
         <ReferenceArrayInput reference="users" source="participantIds">

--- a/src/components/users.js
+++ b/src/components/users.js
@@ -6,9 +6,10 @@ import {
   EditButton,
   TextField,
   NumberField,
-  EmailField,
+  ReferenceField,
   TextInput,
   NumberInput,
+  ReferenceInput,
   SimpleForm,
   SearchInput,
 } from 'react-admin';
@@ -24,7 +25,9 @@ export function UserList({permissions, ...props}) {
       filters={userFilters}>
       <Datagrid rowClick="edit">
         <TextField source="username" />
-        <EmailField source="email" />
+        <ReferenceField reference="emails" source="id" label="email">
+          <TextField source="email" />
+        </ReferenceField>
         <NumberField source="age" />
         <TextField source="gender" />
         <TextField source="housing" />
@@ -41,7 +44,9 @@ export function UserEdit(props) {
     <Edit {...props}>
       <SimpleForm>
         <TextInput source="username" />
-        <TextInput source="email" />
+        <ReferenceInput reference="emails" source="email" disabled>
+          <TextInput />
+        </ReferenceInput>
         <NumberInput source="age" />
         <TextInput source="gender" />
         <TextInput source="housing" />


### PR DESCRIPTION
These changes will pull the emails from the `emails` firestore collection, rather than using the `email` field from the `users` collection. This PR also creates a new emails resource tab on the dashboard for the `emails` collection, whose table has two fields (email and ID)

Screenshots:
![Screenshot 2022-11-09 at 12 34 12 AM](https://user-images.githubusercontent.com/41856541/200622707-a50e828f-da3b-4c71-87c9-ffa79232051c.png)
![Screenshot 2022-11-09 at 12 34 44 AM](https://user-images.githubusercontent.com/41856541/200622714-1f3843a6-1169-4655-b6ef-8a7c9ae79c14.png)
![Screenshot 2022-11-09 at 12 33 28 AM](https://user-images.githubusercontent.com/41856541/200622733-268c6d7f-a2de-43a0-9a66-cb9c472c954a.png)
